### PR TITLE
Improve SEO by adding lang attribute and canonical URL logic

### DIFF
--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -3,12 +3,14 @@ import { GoogleAnalytics } from "@next/third-parties/google";
 import { Analytics } from "@vercel/analytics/react";
 import Head from "next/head";
 import { StructuredData } from "../components/StructuredData/StructuredData";
+import { useRouter } from "next/router";
 
 import "../styles/globals.css";
 
 const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_MEASUREMENT_ID;
 
 function MyApp({ Component, pageProps }) {
+  const router = useRouter();
   const { frontmatter } = pageProps;
   const { title, description, featuredImage, tags } = frontmatter || {};
 
@@ -21,7 +23,8 @@ function MyApp({ Component, pageProps }) {
   const ogKeywordsWithFallback =
     tags?.join(", ") ||
     "marcus, smith, software, engineer, blog, youtube, analytics";
-  const canonicalUrl = `https://www.marcusmth.com${pageProps.path || ""}`;
+  const canonicalPath = (pageProps.path || router.asPath || "").split("?")[0];
+  const canonicalUrl = `https://www.marcusmth.com${canonicalPath}`;
 
   return (
     <>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,17 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;


### PR DESCRIPTION
## Summary
- add custom `_document` to set html lang attribute
- generate canonical URL using router path when no explicit path is provided

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685cda51e1cc8326bb2c7dd30df9a7f8