### PR TITLE
Fix spelling in Linear Top Issue blog

### DIFF
--- a/content/blog/linear-top-issue-app.md
+++ b/content/blog/linear-top-issue-app.md
@@ -1,6 +1,6 @@
 ---
 title: "Building Linear Top Issue utilizing the Linear API"
-description: "Learnings while building an app on top of Linear's OAuth 2.0 and GraphQL api"
+description: "Learnings while building an app on top of Linear's OAuth 2.0 and GraphQL API"
 date: "2025-06-20T18:25:11.908Z"
 lastUpdated: "2025-06-20T18:25:11.908Z"
 tags: ["linear", "nextjs", "vercel"]


### PR DESCRIPTION
## Summary
- fix spelling of `API` in blog post

## Testing
- `npm run format`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cdcb6f6f48326a16b339914425786