### PR TITLE
Server Side render markdown content in posts

### DIFF
--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -36,7 +36,7 @@ export default function PostContent({
         const videoId = part.split(/=|\n/)[1];
         return <YouTubeEmbed key={index} videoId={videoId} />;
       }
-      return <span key={index} dangerouslySetInnerHTML={{ __html: part }} />;
+      return <div key={index} dangerouslySetInnerHTML={{ __html: part }} />;
     });
   };
 
@@ -51,7 +51,7 @@ export default function PostContent({
         const videoId = part.split(/[\n=]/)[1];
         return <YouTubeEmbed key={index} videoId={videoId} />;
       }
-      return <span key={index} dangerouslySetInnerHTML={{ __html: part }} />;
+      return <div key={index} dangerouslySetInnerHTML={{ __html: part }} />;
     });
   };
 

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,0 +1,5 @@
+import md from "markdown-it";
+
+export function markdownToHtml(markdown: string): string {
+  return md().render(markdown);
+}

--- a/pages/[slug]/index.page.tsx
+++ b/pages/[slug]/index.page.tsx
@@ -1,7 +1,7 @@
 import fs from "fs";
 import matter from "gray-matter";
 import PostContent from "../../components/PostContent/PostContent";
-import md from "markdown-it";
+import { markdownToHtml } from "../../lib/markdown";
 
 export async function getStaticPaths() {
   const files = fs.readdirSync("content/blog");
@@ -19,7 +19,7 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params: { slug } }) {
   const fileName = fs.readFileSync(`content/blog/${slug}.md`, "utf-8");
   const { data: frontmatter, content } = matter(fileName);
-  const htmlContent = md().render(content);
+  const htmlContent = markdownToHtml(content);
   return {
     props: {
       frontmatter,

--- a/pages/[slug]/index.page.tsx
+++ b/pages/[slug]/index.page.tsx
@@ -1,6 +1,7 @@
 import fs from "fs";
 import matter from "gray-matter";
 import PostContent from "../../components/PostContent/PostContent";
+import md from "markdown-it";
 
 export async function getStaticPaths() {
   const files = fs.readdirSync("content/blog");
@@ -18,14 +19,22 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params: { slug } }) {
   const fileName = fs.readFileSync(`content/blog/${slug}.md`, "utf-8");
   const { data: frontmatter, content } = matter(fileName);
+  const htmlContent = md().render(content);
   return {
     props: {
       frontmatter,
       content,
+      htmlContent, // new prop
     },
   };
 }
 
-export default function PostPage({ frontmatter, content }) {
-  return <PostContent frontmatter={frontmatter} content={content} />;
+export default function PostPage({ frontmatter, content, htmlContent }) {
+  return (
+    <PostContent
+      frontmatter={frontmatter}
+      content={content}
+      htmlContent={htmlContent}
+    />
+  );
 }

--- a/pages/[slug]/index.page.tsx
+++ b/pages/[slug]/index.page.tsx
@@ -24,7 +24,7 @@ export async function getStaticProps({ params: { slug } }) {
     props: {
       frontmatter,
       content,
-      htmlContent, // new prop
+      htmlContent,
     },
   };
 }

--- a/pages/cheatsheet/[slug]/index.page.tsx
+++ b/pages/cheatsheet/[slug]/index.page.tsx
@@ -1,7 +1,7 @@
 import fs from "fs";
 import matter from "gray-matter";
 import PostContent from "../../../components/PostContent/PostContent";
-import md from "markdown-it";
+import { markdownToHtml } from "../../../lib/markdown";
 
 export async function getStaticPaths() {
   const files = fs.readdirSync("content/cheatsheet");
@@ -19,7 +19,7 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params: { slug } }) {
   const fileName = fs.readFileSync(`content/cheatsheet/${slug}.md`, "utf-8");
   const { data: frontmatter, content } = matter(fileName);
-  const htmlContent = md().render(content);
+  const htmlContent = markdownToHtml(content);
   return {
     props: {
       frontmatter,

--- a/pages/cheatsheet/[slug]/index.page.tsx
+++ b/pages/cheatsheet/[slug]/index.page.tsx
@@ -1,6 +1,7 @@
 import fs from "fs";
 import matter from "gray-matter";
 import PostContent from "../../../components/PostContent/PostContent";
+import md from "markdown-it";
 
 export async function getStaticPaths() {
   const files = fs.readdirSync("content/cheatsheet");
@@ -18,14 +19,22 @@ export async function getStaticPaths() {
 export async function getStaticProps({ params: { slug } }) {
   const fileName = fs.readFileSync(`content/cheatsheet/${slug}.md`, "utf-8");
   const { data: frontmatter, content } = matter(fileName);
+  const htmlContent = md().render(content);
   return {
     props: {
       frontmatter,
       content,
+      htmlContent,
     },
   };
 }
 
-export default function PostPage({ frontmatter, content }) {
-  return <PostContent frontmatter={frontmatter} content={content} />;
+export default function PostPage({ frontmatter, content, htmlContent }) {
+  return (
+    <PostContent
+      frontmatter={frontmatter}
+      content={content}
+      htmlContent={htmlContent}
+    />
+  );
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Post content is now server-side rendered from markdown to HTML, improving SEO and initial load performance.

- **New Features**
  - Converts markdown to HTML during static generation and passes it to the post component.
  - Handles YouTube embeds in server-rendered HTML.

<!-- End of auto-generated description by cubic. -->

