### PR TITLE
FlightClaw Blog

### DIFF
--- a/content/blog/how-i-use-ai-with-flightclaw-to-find-the-best-flights-for-my-weekly-super-commute.md
+++ b/content/blog/how-i-use-ai-with-flightclaw-to-find-the-best-flights-for-my-weekly-super-commute.md
@@ -35,7 +35,7 @@ That is exactly the sort of task AI is good at when it has a clear set of rules.
 
 The first skill is `flightclaw`, which handles the search mechanics. In my local skill, the rule is explicit: always pass `--exclude-basic` so I get true Main Cabin pricing rather than accidentally comparing against Basic Economy.
 
-The second skill is my `supercommute` skill, which defines how I want the search results interpreted.
+The second skill is my private `supercommute` skill, which defines how I want the search results interpreted.
 
 That skill encodes a few real preferences:
 
@@ -43,18 +43,6 @@ That skill encodes a few real preferences:
 - Use non-stop flights only.
 - Search outbound flights in the **6am to 9am** window on Monday and Tuesday.
 - Search return flights in the **6pm to 9pm** window on Thursday and Friday.
-- Prefer Delta enough that I treat it as worth paying about **15% more**.
-- Penalize flights that leave before 7am.
-- Penalize return flights that leave after 6:30pm.
-- Discount BUR arrivals by **$20** because BUR gets me home faster and cheaper than LAX.
-
-That internal ranking formula in my skill looks like this:
-
-```text
-effective = (sticker × delta_factor) + early_out_penalty + late_return_penalty - bur_discount
-```
-
-This is the part I care about most. AI becomes useful when it stops acting like a search engine and starts acting like an opinionated assistant with my rules.
 
 ## What the Search Actually Looks Like
 
@@ -79,21 +67,6 @@ That gives me four pairing sets to compare:
 - Tue-Fri
 
 Without AI, I would still be able to do this. I just would not do it consistently.
-
-## What Makes This Better Than Just Sorting by Price
-
-The cheapest flight is often not the best flight for a weekly commute.
-
-If Delta is slightly more expensive, I may still prefer it because I value reliability, miles, and the upgrade chance that comes with status. If a flight lands at BUR instead of LAX, that matters because getting home from BUR is meaningfully easier for me. If a return leaves too late, I feel it at the end of the week.
-
-My `supercommute` skill captures those tradeoffs directly. For example:
-
-- Delta gets a `0.85` multiplier in my internal scoring.
-- A 6:00am outbound gets a penalty relative to a 7:00am departure.
-- A 7:30pm return gets a penalty relative to a 6:30pm return.
-- BUR gets a `$20` effective discount.
-
-The output I want still shows the sticker price only. The scoring stays internal. That keeps the recommendation easy to scan while still reflecting how I actually make the decision.
 
 ## Where Claude Code Fits In
 

--- a/content/blog/how-i-use-ai-with-flightclaw-to-find-the-best-flights-for-my-weekly-super-commute.md
+++ b/content/blog/how-i-use-ai-with-flightclaw-to-find-the-best-flights-for-my-weekly-super-commute.md
@@ -1,0 +1,149 @@
+---
+title: "How I Use AI with FlightClaw to Find the Best Flights for My Weekly Super Commute"
+description: "My workflow for using AI, FlightClaw, and Claude Code to search LAX, BUR, SFO, and SJC, compare real super commute options, and choose the flights that best fit my weekly commute to Menlo Park."
+date: "2026-04-04T09:00:00.000Z"
+lastUpdated: "2026-04-04T09:00:00.000Z"
+tags: ["ai", "travel", "remote-work"]
+path: blog
+isPublished: true
+---
+
+My weekly super commute between Los Angeles and the Bay Area is repetitive enough to optimize, but variable enough that I don't want to do it by hand every week. There are too many combinations to check casually: LAX or BUR on the LA side, SFO or SJC on the Bay side, Monday or Tuesday outbound, Thursday or Friday return, and then all the timing tradeoffs inside each of those.
+
+That is where AI has become genuinely useful for me.
+
+I use [FlightClaw](https://flightclaw.com/) to do the flight searching and price tracking, and I use [Claude Code](https://www.anthropic.com/claude-code/) to apply my preferences consistently. The result is not just "find the cheapest fare." It is a system that searches the right routes, ignores the wrong fares, ranks flights the way I actually travel, and gives me a recommendation I can book quickly.
+
+If you want the airport-side commute analysis first, I already wrote that up in [Optimizing the LA–SF Super Commute](/optimizing-the-la-sf-super-commute). This post is the AI layer I now use on top of that.
+
+## Why AI Helps Here
+
+The raw problem is simple: find a flight from LA to the Bay Area and back.
+
+The real problem is messier:
+
+- I want non-stop flights only.
+- I want to exclude Basic Economy.
+- I want to search **LAX + BUR × SFO + SJC**.
+- I want Monday and Tuesday morning outbound options.
+- I want Thursday and Friday evening return options.
+- I care about price, but I also care about airline, arrival airport, and whether a flight is annoyingly early or annoyingly late.
+
+That is exactly the sort of task AI is good at when it has a clear set of rules.
+
+## The Two Skills I Use
+
+The first skill is `flightclaw`, which handles the search mechanics. In my local skill, the rule is explicit: always pass `--exclude-basic` so I get true Main Cabin pricing rather than accidentally comparing against Basic Economy.
+
+The second skill is my `supercommute` skill, which defines how I want the search results interpreted.
+
+That skill encodes a few real preferences:
+
+- Search all 4 airport combinations.
+- Use non-stop flights only.
+- Search outbound flights in the **6am to 9am** window on Monday and Tuesday.
+- Search return flights in the **6pm to 9pm** window on Thursday and Friday.
+- Prefer Delta enough that I treat it as worth paying about **15% more**.
+- Penalize flights that leave before 7am.
+- Penalize return flights that leave after 6:30pm.
+- Discount BUR arrivals by **$20** because BUR gets me home faster and cheaper than LAX.
+
+That internal ranking formula in my skill looks like this:
+
+```text
+effective = (sticker × delta_factor) + early_out_penalty + late_return_penalty - bur_discount
+```
+
+This is the part I care about most. AI becomes useful when it stops acting like a search engine and starts acting like an opinionated assistant with my rules.
+
+## What the Search Actually Looks Like
+
+FlightClaw is flexible enough to search multiple airports and date ranges in one pass. The examples in the skill are for routes like `LHR` to `JFK`, but the same structure is what I use for my own commute.
+
+A representative search looks like this:
+
+```bash
+python skills/flightclaw/scripts/search-flights.py LAX,BUR SFO,SJC 2025-07-01 --date-to 2025-07-03 --stops NON_STOP --exclude-basic --depart-after 06:00 --depart-before 09:00
+```
+
+That expands into multiple route and date combinations automatically. For my weekly pattern, the `supercommute` skill tells the AI to do that for both directions:
+
+- Outbound: Monday and Tuesday mornings
+- Return: Thursday and Friday evenings
+
+That gives me four pairing sets to compare:
+
+- Mon-Thu
+- Mon-Fri
+- Tue-Thu
+- Tue-Fri
+
+Without AI, I would still be able to do this. I just would not do it consistently.
+
+## What Makes This Better Than Just Sorting by Price
+
+The cheapest flight is often not the best flight for a weekly commute.
+
+If Delta is slightly more expensive, I may still prefer it because I value reliability, miles, and the upgrade chance that comes with status. If a flight lands at BUR instead of LAX, that matters because getting home from BUR is meaningfully easier for me. If a return leaves too late, I feel it at the end of the week.
+
+My `supercommute` skill captures those tradeoffs directly. For example:
+
+- Delta gets a `0.85` multiplier in my internal scoring.
+- A 6:00am outbound gets a penalty relative to a 7:00am departure.
+- A 7:30pm return gets a penalty relative to a 6:30pm return.
+- BUR gets a `$20` effective discount.
+
+The output I want still shows the sticker price only. The scoring stays internal. That keeps the recommendation easy to scan while still reflecting how I actually make the decision.
+
+## Where Claude Code Fits In
+
+[Claude Code](https://www.anthropic.com/claude-code/) is the orchestration layer for me.
+
+Instead of manually remembering all of these rules each week, I can point Claude Code at my skills and tell it to run the workflow. It reads the instructions in `flightclaw` and `supercommute`, applies the search windows, compares the pairings, and formats the recommendation in a way that is ready to act on.
+
+That part matters. I don't want a wall of flights. I want:
+
+- the recommended itinerary
+- the cheapest itinerary if it is different
+- the pairing totals
+- the exact dates and day of week
+
+One small detail I like in the FlightClaw skill is that it explicitly says to always show the **full date plus day of week** and to verify the day of week before presenting results. That sounds minor, but it is exactly the kind of mistake that causes booking errors on repetitive travel.
+
+## Tracking Prices Instead of Re-Searching From Scratch
+
+I also like that FlightClaw is not only a search tool. It can track routes over time.
+
+The examples in the skill include commands like:
+
+```bash
+python skills/flightclaw/scripts/track-flight.py LHR JFK 2025-07-01 --target-price 400
+python skills/flightclaw/scripts/check-prices.py --threshold 5
+```
+
+For my use case, that means I can track a commute pattern, set a target price, and have the system check whether it has moved enough to matter. That is a much better fit for recurring travel than treating every week as a brand new search.
+
+## Why This Workflow Works for Me
+
+The bigger pattern here is the same one behind some of my other AI projects: AI is best when it is attached to a narrow problem, a real workflow, and explicit constraints. I wrote about that idea in [Building WhoseHouseBurned.com: A Friday Night AI Agent Hackathon](/blog-whosehouseburned/). The value is not "AI magic." The value is encoding a workflow I already care about and letting the tool run it reliably.
+
+For my commute, that means AI is not replacing judgment. It is applying my judgment consistently.
+
+That has made the weekly search process faster and better:
+
+- I check more combinations.
+- I forget fewer constraints.
+- I compare flights more consistently.
+- I spend less time deciding.
+
+And because the preferences live in skills, the workflow keeps getting better as I refine it.
+
+## Image Placeholder
+
+[Image placeholder: screenshot of a FlightClaw-powered super commute summary showing LAX/BUR to SFO/SJC options, Delta preference scoring, and recommended Mon-Thu vs Tue-Fri pairings]
+
+## Final Thoughts
+
+The main lesson for me is that AI gets a lot more useful when it has structure. [FlightClaw](https://flightclaw.com/) gives me the flight data and tracking. [Claude Code](https://www.anthropic.com/claude-code/) gives me the agent layer that can read my skills and execute the workflow. My `supercommute` skill gives it the actual decision logic.
+
+That combination is what turns "find me a flight" into "find me the best flight for how I really travel."

--- a/content/blog/how-to-use-ai-to-value-your-flight-preferences-and-find-the-best-flight.md
+++ b/content/blog/how-to-use-ai-to-value-your-flight-preferences-and-find-the-best-flight.md
@@ -1,0 +1,170 @@
+---
+title: "How to Use AI to Value Your Flight Preferences and Find the Best Flight"
+description: "A practical workflow for using AI, FlightClaw, and Claude Code to turn personal flight preferences into a repeatable ranking system, with real supercommute examples from LAX, BUR, SFO, and SJC."
+date: "2026-04-04T09:00:00.000Z"
+lastUpdated: "2026-04-04T09:00:00.000Z"
+tags: ["ai", "travel", "remote-work"]
+path: blog
+isPublished: true
+---
+
+# How to Use AI to Value Your Flight Preferences and Find the Best Flight
+
+Most flight searches are still optimized for the cheapest ticket, not the best ticket for how you actually travel.
+
+That works if all you care about is sticker price. It breaks down if you have real preferences like airline status, airport convenience, refundability, or departure times that make a trip meaningfully better or worse.
+
+For my weekly LA to Bay Area super commute, I use [FlightClaw](https://flightclaw.com/) for search and tracking, and [Claude Code](https://www.anthropic.com/product/claude-code) to apply my preferences consistently. The useful part is not just "AI finds flights." The useful part is that AI can follow a decision framework I already know I care about.
+
+If you want the airport-side data first, read [Optimizing the LA–SF Super Commute](/optimizing-the-la-sf-super-commute). This post is about the layer on top of that: turning travel preferences into a scoring system an AI agent can actually use.
+
+## The Core Idea
+
+The best flight is usually not the cheapest flight.
+
+For my commute, I care about at least six things:
+
+- non-stop only
+- no Basic Economy
+- Delta gets real credit because I am Delta Silver
+- very early outbound flights are worse
+- very late return flights are worse
+- BUR is better than LAX for getting home
+
+That is enough complexity that doing it by memory every week gets inconsistent.
+
+My `supercommute` skill turns those preferences into an internal formula:
+
+```text
+effective = (sticker × delta_factor) + early_out_penalty + late_return_penalty - bur_discount
+```
+
+And the actual values are opinionated:
+
+- Delta flights get a `0.85` factor
+- departures before 7:00am get a penalty of `$25` per hour
+- returns after 6:30pm get a penalty of `$30` per hour
+- BUR gets a `$20` discount
+
+That formula is not meant to be universal. It is meant to be mine.
+
+## Why AI Helps
+
+My weekly search pattern is not one route. It is a matrix:
+
+- `LAX` and `BUR` on the LA side
+- `SFO` and `SJC` on the Bay side
+- Monday and Tuesday outbound
+- Thursday and Friday return
+
+That means four airport combinations and four day pairings before even comparing airlines and times. My skill tells the AI to search all of them, keep only non-stop options, exclude Basic Economy, and then rank the results using my scoring rules.
+
+This is exactly the kind of task AI is good at when the rules are explicit and the output format is constrained.
+
+## The Two Pieces of the Workflow
+
+The first piece is `flightclaw`, which does the actual search and tracking. The skill explicitly says to always use `--exclude-basic`, which matters because I want real Main Cabin pricing, not fake-cheap Basic Economy comparisons.
+
+The second piece is my `supercommute` skill, which defines how to search and how to rank:
+
+- outbound: Monday or Tuesday, 6am to 9am
+- return: Thursday or Friday, 6pm to 9pm
+- non-stop only
+- exclude Frontier and Spirit
+- treat Southwest as valid because its fares are refundable
+- avoid switching airlines for trivial savings
+
+Then Claude Code reads both skills and returns a recommendation in a format I can act on quickly: recommended itinerary, cheapest itinerary if different, and all combo totals.
+
+## Real Examples From My Supercommute
+
+This gets more useful when the numbers are real.
+
+In my local supercommute notes, I had these Delta roundtrip examples:
+
+- May 26 and May 28: `$216` roundtrip
+- June 1 and June 4: `$247` roundtrip in one snapshot
+- June 1 and June 4: `$280` roundtrip in another snapshot
+
+That alone is enough to show why price tracking matters. A commute pattern that was `$216` one week can be `$247` or `$280` in a later snapshot.
+
+Now apply the preference model:
+
+- `$216` on Delta becomes an internal effective score of `$183.60` before timing adjustments
+- `$247` on Delta becomes `$209.95`
+- `$280` on Delta becomes `$238.00`
+
+That is the first big lesson: if you genuinely prefer one airline, encode that preference directly instead of pretending you do not.
+
+The second lesson is that schedule matters too. Under my skill:
+
+- a `6:30am` outbound adds a `$12.50` penalty
+- an `8:00pm` return adds a `$45` penalty
+- a BUR arrival subtracts `$20`
+
+So a `$247` Delta itinerary is not always the same `$247` Delta itinerary. Internally:
+
+- `$247` Delta with a 6:30am outbound scores `$222.45`
+- `$247` Delta with an 8:00pm return scores `$254.95`
+- `$247` Delta with a BUR arrival scores `$189.95`
+
+That is much closer to how I actually experience the trip.
+
+## Ground Truth Matters Too
+
+The scoring rules are not arbitrary. They come from the commute itself.
+
+In my supercommute timekeeping data:
+
+- LAX outbound trips averaged about `$49.69` and `39.3` minutes car-to-gate
+- BUR outbound trips averaged about `$51.36` and `34.6` minutes car-to-gate
+- one BUR trip on January 26, 2026 was just `$32.75` and `31` minutes car-to-gate
+
+And in my separate analysis in [Optimizing the LA–SF Super Commute](/optimizing-the-la-sf-super-commute), BUR also performed better for getting home on return legs. That is why my skill includes a BUR discount instead of treating all airports as interchangeable.
+
+This is the real opportunity with AI: not replacing judgment, but codifying judgment that was earned from repeated trips.
+
+## What FlightClaw and Claude Code Each Do
+
+[FlightClaw](https://flightclaw.com/) is the data layer. It searches Google Flights, handles multiple airport combinations, supports date ranges, and can track routes over time instead of forcing me to start from scratch each week.
+
+[Claude Code](https://www.anthropic.com/product/claude-code) is the decision layer. It reads my skills, applies the rules consistently, compares the combinations, and returns something closer to a recommendation than a search result.
+
+That combination is what makes the workflow useful. A raw flight search gives me options. A structured AI workflow gives me a decision.
+
+## What I Think Most People Should Do
+
+You do not need my exact formula. You need your own.
+
+If you fly often, start by writing down the things you repeatedly trade off:
+
+- preferred airlines
+- best and worst departure windows
+- preferred airports
+- refundability requirements
+- baggage rules
+- whether layovers are ever acceptable
+
+Then assign rough dollar values to those preferences. They do not need to be perfect. They only need to be directionally honest.
+
+Once you do that, AI becomes much more useful because it can optimize for your actual behavior instead of an abstract cheapest-price metric.
+
+## Related Posts
+
+If you want more context around how I think about AI workflows and this commute specifically:
+
+- [Optimizing the LA–SF Super Commute](/optimizing-the-la-sf-super-commute)
+- [Building WhoseHouseBurned.com: A Friday Night AI Agent Hackathon](/whosehouseburned-hackathon)
+- [Why I created an AI blog for SEO](/beautiful-roads-ai-blog-for-seo)
+
+## Image Placeholder
+
+[Image placeholder: a side-by-side graphic showing sticker price vs effective price for LAX/BUR to SFO/SJC options, with Delta preference and time penalties highlighted]
+
+## Final Thoughts
+
+The best use of AI in travel is not asking a chatbot for a cheap flight. It is giving an AI system your real preferences, a repeatable search process, and a way to rank tradeoffs honestly.
+
+That is what my supercommute workflow does. [FlightClaw](https://flightclaw.com/) handles the search and tracking. [Claude Code](https://www.anthropic.com/product/claude-code) handles the orchestration. My `supercommute` skill handles the judgment.
+
+Once that structure exists, finding the best flight gets much faster.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish two posts documenting a `flightclaw` + Claude Code workflow to rank and track LA↔Bay Area flights from explicit preferences.

Covers LAX/BUR × SFO/SJC non-stops with `--exclude-basic`; adds scoring values (Delta 0.85, early $25/hr <7:00, late $30/hr >18:30, BUR −$20), filters (no Frontier/Spirit; Southwest ok; avoid trivial airline switches), and tracking with target alerts and book-ready output (recommended vs cheapest, pairing totals, day-of-week checks).

<sup>Written for commit 58ff7597d24e69668a81af621ac7ae197c5cc14a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

