### PR TITLE
[codex] Fix homepage image fit

### DIFF
--- a/components/PostItem/PostItem.tsx
+++ b/components/PostItem/PostItem.tsx
@@ -58,7 +58,7 @@ export function PostItem({
               <Image
                 src={`/images/${featuredImage?.src}`}
                 alt={featuredImage?.alt}
-                className="object-contain"
+                className="object-contain object-center"
                 layout="fill"
                 priority
                 placeholder="empty"

--- a/components/PostItem/PostItem.tsx
+++ b/components/PostItem/PostItem.tsx
@@ -54,11 +54,11 @@ export function PostItem({
             </span>
           </div>
           {featuredImage && (
-            <div className="relative h-44 w-full flex-shrink-0 overflow-hidden rounded-md md:h-36 md:w-52">
+            <div className="relative h-44 w-full flex-shrink-0 overflow-hidden rounded-md bg-gray-50 md:h-36 md:w-52">
               <Image
                 src={`/images/${featuredImage?.src}`}
                 alt={featuredImage?.alt}
-                className="object-cover"
+                className="object-contain"
                 layout="fill"
                 priority
                 placeholder="empty"


### PR DESCRIPTION
## Summary
- update homepage post card images to use `object-contain` instead of `object-cover`
- keep the existing fixed card dimensions while preserving image aspect ratio
- add a light background so smaller images still render cleanly inside the frame

## Why
Homepage images were being cropped when their intrinsic aspect ratio did not match the card frame. Smaller images could also look awkward because the card assumed a cover-style crop.

## Impact
Homepage post images now always fit within the card bounds without distortion or cropping, including images that are smaller than the container.

## Testing
- `yarn lint` *(fails due to existing repo script issue: `next lint --fix` now errors with `unknown option '--fix'` on the installed Next.js version)*
- `yarn build` *(blocked by existing stale `.next/lock` from a prior build process in this environment)*

## Risks
- Images will letterbox within the existing card frame instead of fully filling it, which is intentional for preserving full image visibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix homepage post card image rendering by switching to `object-contain` (from `object-cover`), centering images with `object-center`, and adding a light `bg-gray-50` container. Images now preserve aspect ratio, are centered without cropping or distortion, and card sizes stay the same.

<sup>Written for commit a3cfe1f508677a6792b420804c4b6113dc67e297. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

