### PR TITLE
[codex] Match post content width to featured image

### DIFF
--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -75,7 +75,7 @@ export default function PostContent({
         </div>
       )}
 
-      <div className="prose">
+      <div className="prose max-w-none">
         <h1 className="text-4xl font-bold mb-2">{frontmatter.title}</h1>
         <div className="flex items-center text-gray-600 mb-4">
           <span className="mr-4">


### PR DESCRIPTION
## Summary
- remove the default Tailwind Typography width cap from post content pages
- let article text use the full `PageShell` content width so it aligns with the featured image above
- preserve the existing mobile side padding from the page shell

## Why
A previous mobile padding change improved readability on small screens, but on wide screens the article body remained narrower than the featured image because the post content used Tailwind's default `prose` max width.

## Impact
On blog, cheatsheet, and reading post pages, the text content now lines up with the featured image width on larger screens while keeping the existing mobile gutters.

## Testing
- `yarn lint` *(fails due to existing repo script issue: `next lint --fix` now errors with `unknown option '--fix'` on the installed Next.js version)*
- `yarn build` *(fails in this sandbox because Turbopack attempts to create a process and bind to a port while processing CSS: `Operation not permitted (os error 1)`)*

## Risks
- Wider prose lines on desktop may feel less constrained than before, but this is the intended alignment change to match the featured image and page content column.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match post body width to the featured image so text aligns on larger screens while keeping mobile gutters. Adds `max-w-none` to the `prose` container in `PostContent` so content uses the full `PageShell` width.

<sup>Written for commit a27a2e784f9dbc7d422ccc2b32b39a9c35c374e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

