### PR TITLE
[codex] Show full post list images

### DIFF
--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -77,8 +77,8 @@ export default function PostContent({
 
       <div className="prose">
         <h1 className="text-4xl font-bold mb-2">{frontmatter.title}</h1>
-        <div className="flex items-center text-gray-600 mb-4">
-          <span className="mr-4">
+        <div className="mb-4 text-gray-600">
+          <span className="block mb-2">
             {new Date(frontmatter.lastUpdated).toLocaleDateString("en-US", {
               year: "numeric",
               month: "long",

--- a/components/PostItem/PostItem.tsx
+++ b/components/PostItem/PostItem.tsx
@@ -54,7 +54,7 @@ export function PostItem({
             </span>
           </div>
           {featuredImage && (
-            <div className="relative h-44 w-full flex-shrink-0 overflow-hidden rounded-md bg-gray-50 md:h-36 md:w-52">
+            <div className="relative h-44 w-full flex-shrink-0 overflow-hidden rounded-md md:h-36 md:w-52">
               {/* Keep post list images fully visible: preserve aspect ratio, shrink to fit, and center instead of cropping. */}
               <Image
                 src={`/images/${featuredImage?.src}`}

--- a/components/PostItem/PostItem.tsx
+++ b/components/PostItem/PostItem.tsx
@@ -59,8 +59,8 @@ export function PostItem({
               <Image
                 src={`/images/${featuredImage?.src}`}
                 alt={featuredImage?.alt}
-                className="object-contain object-center"
                 layout="fill"
+                style={{ objectFit: "contain", objectPosition: "center" }}
                 priority
                 placeholder="empty"
               />

--- a/components/PostItem/PostItem.tsx
+++ b/components/PostItem/PostItem.tsx
@@ -54,11 +54,12 @@ export function PostItem({
             </span>
           </div>
           {featuredImage && (
-            <div className="relative h-44 w-full flex-shrink-0 overflow-hidden rounded-md md:h-36 md:w-52">
+            <div className="relative h-44 w-full flex-shrink-0 overflow-hidden rounded-md bg-gray-50 md:h-36 md:w-52">
+              {/* Keep post list images fully visible: preserve aspect ratio, shrink to fit, and center instead of cropping. */}
               <Image
                 src={`/images/${featuredImage?.src}`}
                 alt={featuredImage?.alt}
-                className="object-cover"
+                className="object-contain object-center"
                 layout="fill"
                 priority
                 placeholder="empty"

--- a/components/PostItem/PostItem.tsx
+++ b/components/PostItem/PostItem.tsx
@@ -45,13 +45,16 @@ export function PostItem({
               {title}
             </h2>
             <p className="mb-3 text-gray-700 no-underline">{description}</p>
-            <span className="font-light text-sm text-gray-500">
-              {new Date(lastUpdated).toLocaleDateString("en-US", {
-                year: "numeric",
-                month: "long",
-                day: "numeric",
-              })}
-            </span>
+            <div className="flex flex-wrap items-center gap-4">
+              <span className="font-light text-sm text-gray-500">
+                {new Date(lastUpdated).toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </span>
+              {!!visibleTags?.length && <TagList tags={visibleTags} />}
+            </div>
           </div>
           {featuredImage && (
             <div className="relative h-44 w-full flex-shrink-0 overflow-hidden rounded-md md:h-36 md:w-52">
@@ -68,11 +71,6 @@ export function PostItem({
           )}
         </div>
       </div>
-      {!!visibleTags?.length && (
-        <div className="pointer-events-none relative z-20 px-6 pb-6">
-          <TagList tags={visibleTags} />
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update homepage and post list card images to use `object-contain` instead of `object-cover`
- keep images centered inside the existing card frame
- add a short inline comment documenting that full-image visibility is intentional and should not be changed back to cropping
- add a light background behind the image frame so smaller images render cleanly inside the card

## Why
Post list images were being cropped because the card used a cover-style image fill. The desired behavior is to always show the full image, preserve its aspect ratio, and shrink it to fit the existing card area while keeping it centered.

## Impact
Homepage and post list cards now show the complete image without cutoff or distortion, including smaller images and images with wide or tall aspect ratios.

## Testing
- `yarn lint` *(fails due to existing repo script issue: `next lint --fix` now errors with `unknown option '--fix'` on the installed Next.js version)*
- `yarn build` *(did not complete successfully in this sandbox; the build left `.next/lock` during the Turbopack compile phase, which is consistent with the existing environment limitation around sandboxed Next.js builds here)*

## Risks
- Images will letterbox inside the fixed card frame instead of filling it edge to edge, which is the intended tradeoff to keep the full image visible.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show full images in post list cards by using `next/image` with objectFit: "contain" and centered positioning. Remove the background fill, add a clarifying no-crop comment, move tags beside the date in the card metadata, and stack post page metadata for easier reading.

<sup>Written for commit 5d8feca9cf9038da7ed898263b1ded2e0d6ca768. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

