### PR TITLE
Remove AI license footer and Creative Commons metadata

### DIFF
--- a/components/PostContent/PostContent.tsx
+++ b/components/PostContent/PostContent.tsx
@@ -3,7 +3,6 @@ import { TagList } from "../TagList/TagList";
 import dynamic from "next/dynamic";
 import { useState, useEffect } from "react";
 import Image from "next/image";
-import Head from "next/head";
 import { markdownToHtml } from "../../lib/markdown";
 
 const YouTubeEmbed = dynamic(() => import("../YouTubeEmbed/YouTubeEmbed"));
@@ -57,12 +56,6 @@ export default function PostContent({
 
   return (
     <PageShell>
-      <Head>
-        <link
-          rel="license"
-          href="https://creativecommons.org/licenses/by/4.0/"
-        />
-      </Head>
       {frontmatter.featuredImage && (
         <div className="mb-8 rounded-lg overflow-hidden shadow-lg max-h-[400px] flex items-center justify-center">
           <Image

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -8,19 +8,7 @@ export default function Layout({ children }): ReactElement {
       <footer className="mt-12 py-8 bg-gray-50">
         <div className="container mx-auto px-4">
           <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
-            <p>
-              © {new Date().getFullYear()} by Marcus Smith. Except where
-              otherwise noted, content on this site is licensed under a{" "}
-              <a
-                href="https://creativecommons.org/licenses/by/4.0/"
-                target="_blank"
-                rel="license noopener noreferrer"
-                className="text-blue-600 hover:text-blue-800"
-              >
-                Creative Commons Attribution 4.0 International License
-              </a>
-              .
-            </p>
+            <p>© {new Date().getFullYear()} Marcus Smith</p>
           </div>
         </div>
       </footer>

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -5,13 +5,6 @@ export default function Layout({ children }): ReactElement {
   return (
     <div className="flex flex-col min-h-screen">
       <main className="container mx-auto flex-1">{children}</main>
-      <footer className="mt-12 py-8 bg-gray-50">
-        <div className="container mx-auto px-4">
-          <div className="flex items-center justify-center gap-2 text-sm text-gray-600">
-            <p>© {new Date().getFullYear()} Marcus Smith</p>
-          </div>
-        </div>
-      </footer>
     </div>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed Creative Commons licensing metadata and removed the footer entirely to match the new site licensing. Dropped the `rel="license"` link and `Head` usage from `PostContent`, and deleted the footer (copyright and license text) from `components/layout.tsx`.

<sup>Written for commit cc49775ece67af890e92037a822d2eb199a3f124. Summary will update on new commits. <a href="https://cubic.dev/pr/MarcusHSmith/marcusmth-nextjs/pull/73?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

